### PR TITLE
Create manual commit guide for GitHub

### DIFF
--- a/DOC/Manual-git-commit-changes
+++ b/DOC/Manual-git-commit-changes
@@ -1,0 +1,62 @@
+# Manual Commit Guide: Adding Files to GitHub
+
+When automated pushes are blocked by permissions, use these steps to add new files (like `euystacio_framework_spa.html`) directly to your repository.
+
+---
+
+## Option 1: Using the GitHub Web Interface (Easiest)
+
+1. **Navigate to your Repository**  
+   Go to the main page of your project repository on GitHub.
+
+2. **Add a New File**  
+   Click the **Add file** dropdown button, then select **Create new file**.
+
+3. **Set the File Path**  
+   In the file path input field, type the desired file name, e.g.:  
+   ```
+   euystacio_framework_spa.html
+   ```
+
+4. **Paste the Code**  
+   Copy the entire content of the HTML file (from `<!DOCTYPE html>` to `</html>`) and paste it into the editor window.
+
+5. **Commit Changes**  
+   - Add a clear commit message, e.g.:  
+     ```
+     Feat: Initial commit of Euystacio Interactive Dashboard SPA
+     ```
+   - Select the option **Commit directly to the main branch**.
+   - Click the green **Commit new file** button.
+
+---
+
+## Option 2: Using Local Git Commands
+
+1. **Save the File**  
+   Save the provided HTML code into a new file named `euystacio_framework_spa.html` in your local project directory.
+
+2. **Stage the File**  
+   Open your terminal and run:
+   ```sh
+   git add euystacio_framework_spa.html
+   ```
+
+3. **Commit the Changes**  
+   ```
+   git commit -m "Feat: Initial commit of Euystacio Interactive Dashboard SPA"
+   ```
+
+4. **Push to GitHub**  
+   ```
+   git push
+   ```
+
+---
+
+## Next Steps
+
+The application is now integrated!  
+If you want to discuss architecture, create supporting docs, or expand functionality, just ask!
+
+---


### PR DESCRIPTION
Added a manual guide for committing changes to GitHub, detailing both web interface and local Git commands.